### PR TITLE
Enhancements

### DIFF
--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -12,4 +12,4 @@ from ._cached_computation import cached_computation
 from ._cached_parallel_computation import (cached_parallel_computation,
                                            secure_parallel_output)
 from ._common import (set_cache_dir, set_dir_levels, set_hash_len,
-                      set_log_level, set_use_hash)
+                      set_log_level, set_read_only, set_use_hash)

--- a/caching/_cached.py
+++ b/caching/_cached.py
@@ -6,7 +6,7 @@ from inspect import signature
 from typing import List, Optional
 
 from ._common import (CacheUsageError, _get_mode, _hash_all, get_cache_dir,
-                      get_use_hash)
+                      get_read_only, get_use_hash)
 
 logger = logging.getLogger("caching")
 
@@ -144,11 +144,15 @@ def cached(
 
             # Only call the function if there is any work to do at all.
             if not computed():
-                clear_previous_outputs()
                 # Now call the wrapped function
                 logger.debug(
                     f"Calling {func.__name__} . Output location: {filename}"
                 )
+                if get_read_only():
+                    raise CacheUsageError(
+                        "Cache is in read only mode! Will not call function."
+                    )
+                clear_previous_outputs()
                 res = func(*args, **kwargs)
 
                 os.umask(0)  # To ensure all collaborators can access cache

--- a/caching/_cached.py
+++ b/caching/_cached.py
@@ -5,7 +5,7 @@ from functools import wraps
 from inspect import signature
 from typing import List, Optional
 
-from ._common import CacheUsageError, _hash_all, get_cache_dir, get_use_hash
+from ._common import CacheUsageError, _hash_all, get_cache_dir, _get_mode, get_use_hash
 
 logger = logging.getLogger("caching")
 
@@ -116,42 +116,58 @@ def cached(
                 )
             success_token_filename = os.path.join(*path) + ".success"
             filename = os.path.join(*path) + ".pickle"
-            if os.path.isfile(success_token_filename):
-                if not os.path.isfile(filename):
-                    raise Exception(
-                        "Success token is present but file is missing!: "
-                        f"{filename}"
-                    )
-                with open(filename, "rb") as f:
-                    try:
-                        return pickle.load(f)
-                    except Exception:
-                        raise Exception(
-                            "Corrupt cache file due to unpickling error, even "
-                            f"though success token was present!: {filename}"
-                        )
-            else:
-                if os.path.isfile(filename):
-                    assert not os.path.isfile(
-                        success_token_filename
-                    )  # Should be true because we are in the else statement
+
+            def computed():
+                # Check that each of the output files exists
+                if not os.path.exists(filename):
+                    return False
+                # Not checking mode for backwards compatibility reasons.
+                # mode = _get_mode(filename)
+                # if mode != "444":
+                #     return False
+
+                if not os.path.exists(success_token_filename):
+                    return False
+                return True
+
+            def clear_previous_outputs():
+                if os.path.exists(filename):
                     logger.info(
-                        "Success token missing but pickle file is present. "
-                        "Thus pickle file is most likely corrupt. "
-                        f"Will have to recompute: {filename}"
+                        f"Removing possibly corrupted {filename}"
                     )
+                    os.system(f'chmod 666 "{filename}"')
+                    os.remove(filename)
+
+                if os.path.exists(success_token_filename):
+                    logger.info(
+                        f"Removing {success_token_filename}"
+                    )
+                    os.system(f'chmod 666 "{success_token_filename}"')
+                    os.remove(success_token_filename)
+
+            # Only call the function if there is any work to do at all.
+            if not computed():
+                clear_previous_outputs()
+                # Now call the wrapped function
                 logger.debug(
                     f"Calling {func.__name__} . Output location: {filename}"
                 )
                 res = func(*args, **kwargs)
-                os.makedirs(os.path.join(*path[:-1]), exist_ok=True)
+
+                os.umask(0)  # To ensure all collaborators can access cache
+                os.makedirs(os.path.join(*path[:-1]), exist_ok=True, mode=0o777)
                 with open(filename, "wb") as f:
                     pickle.dump(res, f)
                     f.flush()
+                os.system(f'chmod 444 "{filename}"')
+
                 with open(success_token_filename, "w") as f:
                     f.write("SUCCESS\n")
                     f.flush()
                 return res
+            else:
+                with open(filename, "rb") as f:
+                    return pickle.load(f)
 
         return wrapper
 

--- a/caching/_cached.py
+++ b/caching/_cached.py
@@ -5,7 +5,8 @@ from functools import wraps
 from inspect import signature
 from typing import List, Optional
 
-from ._common import CacheUsageError, _hash_all, get_cache_dir, _get_mode, get_use_hash
+from ._common import (CacheUsageError, _get_mode, _hash_all, get_cache_dir,
+                      get_use_hash)
 
 logger = logging.getLogger("caching")
 
@@ -132,16 +133,12 @@ def cached(
 
             def clear_previous_outputs():
                 if os.path.exists(filename):
-                    logger.info(
-                        f"Removing possibly corrupted {filename}"
-                    )
+                    logger.info(f"Removing possibly corrupted {filename}")
                     os.system(f'chmod 666 "{filename}"')
                     os.remove(filename)
 
                 if os.path.exists(success_token_filename):
-                    logger.info(
-                        f"Removing {success_token_filename}"
-                    )
+                    logger.info(f"Removing {success_token_filename}")
                     os.system(f'chmod 666 "{success_token_filename}"')
                     os.remove(success_token_filename)
 

--- a/caching/_cached_computation.py
+++ b/caching/_cached_computation.py
@@ -135,7 +135,7 @@ def _maybe_write_usefull_stuff_cached_computation(
 def cached_computation(
     exclude_args: List = [],
     output_dirs: List = [],
-    write_extra_log_files: bool = True,
+    write_extra_log_files: bool = False,
 ):
     """
     Cache a function's outputs.

--- a/caching/_cached_computation.py
+++ b/caching/_cached_computation.py
@@ -6,7 +6,8 @@ from inspect import signature
 from typing import List
 
 from ._common import (CacheUsageError, _get_func_caching_dir, _get_mode,
-                      _validate_decorator_args, get_cache_dir, get_use_hash)
+                      _validate_decorator_args, get_cache_dir, get_read_only,
+                      get_use_hash)
 
 logger = logging.getLogger("caching")
 
@@ -298,11 +299,15 @@ def cached_computation(
 
             # Only call the function if there is any work to do at all.
             if not computed():
-                clear_previous_outputs()
                 # Now call the wrapped function
                 logger.debug(
                     f"Calling {func.__name__} . Output location: {filename}"
                 )
+                if get_read_only():
+                    raise CacheUsageError(
+                        "Cache is in read only mode! Will not call function."
+                    )
+                clear_previous_outputs()
                 func(*args, **kwargs)
 
                 # Now verify that all outputs are there.

--- a/caching/_cached_computation.py
+++ b/caching/_cached_computation.py
@@ -5,14 +5,8 @@ from functools import wraps
 from inspect import signature
 from typing import List
 
-from ._common import (
-    CacheUsageError,
-    _get_func_caching_dir,
-    _get_mode,
-    _validate_decorator_args,
-    get_cache_dir,
-    get_use_hash,
-)
+from ._common import (CacheUsageError, _get_func_caching_dir, _get_mode,
+                      _validate_decorator_args, get_cache_dir, get_use_hash)
 
 logger = logging.getLogger("caching")
 
@@ -279,10 +273,10 @@ def cached_computation(
                         kwargs[output_dir], "result.success"
                     )
                     if os.path.exists(output_success_token_filepath):
-                        logger.info(
-                            f"Removing {output_success_token_filepath}"
+                        logger.info(f"Removing {output_success_token_filepath}")
+                        os.system(
+                            f'chmod 666 "{output_success_token_filepath}"'
                         )
-                        os.system(f'chmod 666 "{output_success_token_filepath}"')
                         os.remove(output_success_token_filepath)
 
             # Make sure that all the output directories exist.

--- a/caching/_cached_computation.py
+++ b/caching/_cached_computation.py
@@ -301,7 +301,7 @@ def cached_computation(
             if not computed():
                 # Now call the wrapped function
                 logger.debug(
-                    f"Calling {func.__name__} . Output location: {filename}"
+                    f"Calling {func.__name__} . Output location: {func_caching_dir}"
                 )
                 if get_read_only():
                     raise CacheUsageError(

--- a/caching/_cached_parallel_computation.py
+++ b/caching/_cached_parallel_computation.py
@@ -148,7 +148,7 @@ def cached_parallel_computation(
     parallel_arg: str,
     exclude_args: List = [],
     output_dirs: List = [],
-    write_extra_log_files: bool = True,
+    write_extra_log_files: bool = False,
 ):
     """
     Cache a parallel function's outputs.

--- a/caching/_cached_parallel_computation.py
+++ b/caching/_cached_parallel_computation.py
@@ -5,14 +5,8 @@ from functools import wraps
 from inspect import signature
 from typing import List
 
-from ._common import (
-    CacheUsageError,
-    _get_func_caching_dir,
-    _get_mode,
-    _validate_decorator_args,
-    get_cache_dir,
-    get_use_hash,
-)
+from ._common import (CacheUsageError, _get_func_caching_dir, _get_mode,
+                      _validate_decorator_args, get_cache_dir, get_use_hash)
 
 logger = logging.getLogger("caching")
 
@@ -321,10 +315,10 @@ def cached_parallel_computation(
                         kwargs[output_dir], parallel_arg_value + ".success"
                     )
                     if os.path.exists(output_success_token_filepath):
-                        logger.info(
-                            f"Removing {output_success_token_filepath}"
+                        logger.info(f"Removing {output_success_token_filepath}")
+                        os.system(
+                            f'chmod 666 "{output_success_token_filepath}"'
                         )
-                        os.system(f'chmod 666 "{output_success_token_filepath}"')
                         os.remove(output_success_token_filepath)
 
             # We will only call the function on the values that have not

--- a/caching/_cached_parallel_computation.py
+++ b/caching/_cached_parallel_computation.py
@@ -353,7 +353,7 @@ def cached_parallel_computation(
             if len(new_parallel_args):
                 # Now call the wrapped function
                 logger.debug(
-                    f"Calling {func.__name__} . Output location: {filename}"
+                    f"Calling {func.__name__} . Output location: {func_caching_dir}"
                 )
                 if get_read_only():
                     raise CacheUsageError(

--- a/caching/_common.py
+++ b/caching/_common.py
@@ -24,6 +24,7 @@ _CACHE_DIR = None
 _USE_HASH = True
 _HASH_LEN = 128
 _DIR_LEVELS = 3
+_READ_ONLY = False
 
 
 def set_cache_dir(cache_dir: str):
@@ -78,6 +79,17 @@ def set_dir_levels(dir_levels: int):
 def get_dir_levels():
     global _DIR_LEVELS
     return _DIR_LEVELS
+
+
+def set_read_only(read_only: bool):
+    logger.info(f"Setting cache to read only mode = {read_only}")
+    global _READ_ONLY
+    _READ_ONLY = read_only
+
+
+def get_read_only():
+    global _READ_ONLY
+    return _READ_ONLY
 
 
 class CacheUsageError(Exception):

--- a/caching/_common.py
+++ b/caching/_common.py
@@ -184,6 +184,6 @@ def _validate_decorator_args(
 
 def _get_mode(path):
     """
-    Get mode of a file (e.g. '664', '555')
+    Get mode of a file (e.g. '666', '444')
     """
     return oct(os.stat(path).st_mode)[-3:]


### PR DESCRIPTION
- Ensure creating directories in 777 mode so that collaborators can access cache.
- Allow turning off the extra log files, which can clog space in some cases (e.g. metric functions with long arguments). Make this the default.
- Enable read-only mode for the cache.